### PR TITLE
Db deployment

### DIFF
--- a/curve-api/curve-api/Data/CurveDBContext.cs
+++ b/curve-api/curve-api/Data/CurveDBContext.cs
@@ -8,6 +8,9 @@ namespace curve_api.Data
 {
     public class CurveDBContext : DbContext
     {
+		public CurveDBContext(DbContextOptions<CurveDBContext> options) : base(options)
+		{
+		}
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {

--- a/curve-api/curve-api/Data/CurveDBContext.cs
+++ b/curve-api/curve-api/Data/CurveDBContext.cs
@@ -2636,7 +2636,9 @@ namespace curve_api.Data
 
                   });
         }
-        public DbSet<Individual> Individuals { get; set; }
+
+		// Set DB tables
+		public DbSet<Individual> Individuals { get; set; }
         public DbSet<Review> Reviews { get; set; }
         public DbSet<ReviewComment> ReviewComments { get; set; }
         public DbSet<Category> Categories { get; set; }

--- a/curve-api/curve-api/Startup.cs
+++ b/curve-api/curve-api/Startup.cs
@@ -40,6 +40,7 @@ namespace curve_api
 												? Configuration["ConnectionStrings:DefaultConnection_CurveDB"] 
 												: Configuration["ConnectionStrings:ProductionConnection_CurveDB"];
 
+			// Register DB context in services
 			services.AddDbContext<CurveDBContext>(options => options.UseSqlServer(connectionString_CurveDB));
 
 			// Register the Swagger generator, defining 1 or more Swagger documents

--- a/curve-api/curve-api/Startup.cs
+++ b/curve-api/curve-api/Startup.cs
@@ -2,11 +2,13 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using curve_api.Data;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.HttpsPolicy;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -17,20 +19,31 @@ namespace curve_api
 {
     public class Startup
     {
-        public Startup(IConfiguration configuration)
-        {
-            Configuration = configuration;
-        }
+		public IConfiguration Configuration { get; }
+		public IHostingEnvironment Environment { get; }
 
-        public IConfiguration Configuration { get; }
+		public Startup(IHostingEnvironment environment)
+		{
+			Environment = environment;
+			var builder = new ConfigurationBuilder().AddEnvironmentVariables();
+			builder.AddUserSecrets<Startup>();
+			Configuration = builder.Build();
+		}
 
-        // This method gets called by the runtime. Use this method to add services to the container.
-        public void ConfigureServices(IServiceCollection services)
+		// This method gets called by the runtime. Use this method to add services to the container.
+		public void ConfigureServices(IServiceCollection services)
         {
             services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_2);
 
-            // Register the Swagger generator, defining 1 or more Swagger documents
-            services.AddSwaggerGen(c =>
+			// Database connection strings
+			var connectionString_CurveDB = Environment.IsDevelopment()
+												? Configuration["ConnectionStrings:DefaultConnection_CurveDB"] 
+												: Configuration["ConnectionStrings:ProductionConnection_CurveDB"];
+
+			services.AddDbContext<CurveDBContext>(options => options.UseSqlServer(connectionString_CurveDB));
+
+			// Register the Swagger generator, defining 1 or more Swagger documents
+			services.AddSwaggerGen(c =>
             {
                 c.SwaggerDoc("v1", new Info { Title = "My API", Version = "v1" });
             });


### PR DESCRIPTION
Not ready to be merged yet. DB seeding not working yet: see message below. Haven't figured out why it's getting that error. Does it have sth to do with the `Id` property itself of the Category entity/model?

Error message in package mgr console:
> The seed entity for entity type 'Category' cannot be added because a non-zero value is required for property 'Id'.