### PR TITLE
Fix typo in curiosity subcategory

### DIFF
--- a/curve-api/curve-api/Data/CurveDBContext.cs
+++ b/curve-api/curve-api/Data/CurveDBContext.cs
@@ -569,7 +569,7 @@ namespace curve_api.Data
                    new SubCategory
                    {
                        Id = n++,
-                       SubCategoryName = "Curiousity",
+                       SubCategoryName = "Curiosity",
                        Score = 1,
                        CategoryId = 2,
 


### PR DESCRIPTION
Fixed typo in curiosity that was messing things up on the front end.